### PR TITLE
operf-micro.0.1 - via opam-publish

### DIFF
--- a/packages/operf-micro/operf-micro.0.1/descr
+++ b/packages/operf-micro/operf-micro.0.1/descr
@@ -1,0 +1,5 @@
+Simple tool for benchmarking the OCaml compiler
+
+operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
+compiler. It provides a minimal framework to compare the performances of 
+different versions of the compiler.

--- a/packages/operf-micro/operf-micro.0.1/opam
+++ b/packages/operf-micro/operf-micro.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "1.2"
+maintainer: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+authors: "Pierre Chambart <pierre.chambart@ocamlpro.com>"
+homepage: "http://www.typerex.org/operf-micro.html"
+bug-reports: "http://github.com/OCamlPro/operf-micro/issues"
+license: "GPLv2"
+dev-repo: "git://github.com/OCamlPro/operf-micro"
+substs: "Makefile.conf"
+build: [make]
+install: [make "install_benchs"]
+remove: [make "uninstall_benchs"]

--- a/packages/operf-micro/operf-micro.0.1/url
+++ b/packages/operf-micro/operf-micro.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/operf-micro/archive/0.1.tar.gz"
+checksum: "288a1c7481722cf68b231958d5f20207"


### PR DESCRIPTION
Simple tool for benchmarking the OCaml compiler

operf-micro is a small tool coming with a set of micro benchmarks for the OCaml
compiler. It provides a minimal framework to compare the performances of 
different versions of the compiler.

---
- Homepage: http://www.typerex.org/operf-micro.html
- Source repo: git://github.com/OCamlPro/operf-micro
- Bug tracker: http://github.com/OCamlPro/operf-micro/issues

---

Pull-request generated by opam-publish v0.2.1
